### PR TITLE
[CAT-14] Add Support for FT1 Segment

### DIFF
--- a/lib/segments/ft1.rb
+++ b/lib/segments/ft1.rb
@@ -1,0 +1,35 @@
+# encoding: UTF-8
+class HL7::Message::Segment::FT1 < HL7::Message::Segment
+  add_field :set_id
+  add_field :transaction_id
+  add_field :transaction_batch_id
+  add_field :transaction_date do |value|
+    convert_to_ts(value)
+  end
+  add_field :transaction_posting_date do |value|
+    convert_to_ts(value)
+  end
+  add_field :transaction_type
+  add_field :transaction_code
+  add_field :transaction_description
+  add_field :transaction_description_alt
+  add_field :transaction_quantity
+  add_field :transaction_amount_extended
+  add_field :transaction_amount_unit
+  add_field :department_code
+  add_field :insurance_plan_id
+  add_field :insurance_amount
+  add_field :assigned_patient_location
+  add_field :fee_schedule
+  add_field :patient_type
+  add_field :diagnosis_code
+  add_field :performed_by_code
+  add_field :ordered_by_code
+  add_field :unit_cost
+  add_field :filler_order_number
+  add_field :entered_by_code
+  add_field :procedure_code
+  add_field :procedure_code_modifier
+  add_field :advanced_beneficiary_notice_code
+  add_field :medically_necessary_duplicate_procedure_reason
+end

--- a/lib/segments/ft1.rb
+++ b/lib/segments/ft1.rb
@@ -1,5 +1,7 @@
 # encoding: UTF-8
 class HL7::Message::Segment::FT1 < HL7::Message::Segment
+  weight 4
+
   add_field :set_id
   add_field :transaction_id
   add_field :transaction_batch_id

--- a/lib/segments/gt1.rb
+++ b/lib/segments/gt1.rb
@@ -1,8 +1,8 @@
 # encoding: UTF-8
 # via https://github.com/bbhoss/ruby-hl7/blob/master/lib/segments/in1.rb
 class HL7::Message::Segment::GT1 < HL7::Message::Segment
-  weight 4
-  
+  weight 2
+
   add_field :set_id
   add_field :guarantor_number
   add_field :guarantor_name

--- a/lib/segments/gt1.rb
+++ b/lib/segments/gt1.rb
@@ -1,6 +1,5 @@
 # encoding: UTF-8
 # via https://github.com/bbhoss/ruby-hl7/blob/master/lib/segments/in1.rb
 class HL7::Message::Segment::GT1 < HL7::Message::Segment
-  weight 2
   add_field :guarantor_name, :idx=>3
 end

--- a/lib/segments/gt1.rb
+++ b/lib/segments/gt1.rb
@@ -2,25 +2,5 @@
 # via https://github.com/bbhoss/ruby-hl7/blob/master/lib/segments/in1.rb
 class HL7::Message::Segment::GT1 < HL7::Message::Segment
   weight 2
-
-  add_field :set_id
-  add_field :guarantor_number
-  add_field :guarantor_name
-  add_field :guarantor_spouse_name
-  add_field :guarantor_address
-  add_field :guarantor_home_phone
-  add_field :guarantor_work_phone
-  add_field :guarantor_dob
-  add_field :guarantor_sex
-  add_field :guarantor_type
-  add_field :guarantor_relationship
-  add_field :guarantor_ssn
-  add_field :guarantor_begin_date
-  add_field :guarantor_end_date
-  add_field :guarantor_priority
-  add_field :guarantor_employer_name
-  add_field :guarantor_employer_address
-  add_field :guarantor_employer_phone
-  add_field :guarantor_employee_id
-  add_field :guarantor_employment_status
+  add_field :guarantor_name, :idx=>3
 end

--- a/lib/segments/gt1.rb
+++ b/lib/segments/gt1.rb
@@ -1,0 +1,24 @@
+# encoding: UTF-8
+# via https://github.com/bbhoss/ruby-hl7/blob/master/lib/segments/in1.rb
+class HL7::Message::Segment::GT1 < HL7::Message::Segment
+  add_field :set_id
+  add_field :guarantor_number
+  add_field :guarantor_name
+  add_field :guarantor_spouse_name
+  add_field :guarantor_address
+  add_field :guarantor_home_phone
+  add_field :guarantor_work_phone
+  add_field :guarantor_dob
+  add_field :guarantor_sex
+  add_field :guarantor_type
+  add_field :guarantor_relationship
+  add_field :guarantor_ssn
+  add_field :guarantor_begin_date
+  add_field :guarantor_end_date
+  add_field :guarantor_priority
+  add_field :guarantor_employer_name
+  add_field :guarantor_employer_address
+  add_field :guarantor_employer_phone
+  add_field :guarantor_employee_id
+  add_field :guarantor_employment_status
+end

--- a/lib/segments/gt1.rb
+++ b/lib/segments/gt1.rb
@@ -1,6 +1,8 @@
 # encoding: UTF-8
 # via https://github.com/bbhoss/ruby-hl7/blob/master/lib/segments/in1.rb
 class HL7::Message::Segment::GT1 < HL7::Message::Segment
+  weight 4
+  
   add_field :set_id
   add_field :guarantor_number
   add_field :guarantor_name

--- a/lib/segments/pid.rb
+++ b/lib/segments/pid.rb
@@ -1,7 +1,7 @@
 # encoding: UTF-8
 class HL7::Message::Segment::PID < HL7::Message::Segment
   weight 1
-  has_children [:NK1,:NTE,:PV1,:PV2,:GT1]
+  has_children [:NK1,:NTE,:PV1,:PV2]
   add_field :set_id
   add_field :patient_id
   add_field :patient_id_list

--- a/lib/segments/pid.rb
+++ b/lib/segments/pid.rb
@@ -1,7 +1,7 @@
 # encoding: UTF-8
 class HL7::Message::Segment::PID < HL7::Message::Segment
   weight 1
-  has_children [:NK1,:NTE,:PV1,:PV2]
+  has_children [:NK1,:NTE,:PV1,:PV2,:GT1]
   add_field :set_id
   add_field :patient_id
   add_field :patient_id_list

--- a/spec/ft1_segment_spec.rb
+++ b/spec/ft1_segment_spec.rb
@@ -4,8 +4,8 @@ require 'spec_helper'
 describe HL7::Message::Segment::FT1 do
   describe 'initialization' do
     context 'with payload' do
-      # from http://www.hosinc.com/Products/Interfaces/interface_documentation.htm
-      let(:payload) { 'FT1|1|48390||20050111|20050112|CH|66000230^AMLODIPINE BESYLATE|AMLODIPINE BESYLATE||1|||1|||||I|||||||' }
+      # based on FT1 payload from http://www.hosinc.com/Products/Interfaces/interface_documentation.htm
+      let(:payload) { 'FT1|1|48390||20050111|20050112|CH|66000230^AMLODIPINE BESYLATE|AMLODIPINE BESYLATE||1|||1|||^^^999999||I|F99.9^Attention-deficit hyperactivity disorder, combined type^ICD-99-CM|9999999^DUCK^DONALD^D|9999999^DUCK^DONALD^D||^99999999||99999^EACH ADDITIONAL 30 MINUTES FOR CRISIS PSYCHOTHERAPY' }
 
       let(:ft1) { described_class.new payload }
 
@@ -26,16 +26,16 @@ describe HL7::Message::Segment::FT1 do
       specify { expect(ft1.department_code).to eq '1' }
       specify { expect(ft1.insurance_plan_id).to eq '' }
       specify { expect(ft1.insurance_amount).to eq '' }
-      specify { expect(ft1.assigned_patient_location).to eq '' }
+      specify { expect(ft1.assigned_patient_location).to eq '^^^999999' }
       specify { expect(ft1.fee_schedule).to eq '' }
       specify { expect(ft1.patient_type).to eq 'I' }
-      specify { expect(ft1.diagnosis_code).to eq '' }
-      specify { expect(ft1.performed_by_code).to eq '' }
-      specify { expect(ft1.ordered_by_code).to eq '' }
+      specify { expect(ft1.diagnosis_code).to eq 'F99.9^Attention-deficit hyperactivity disorder, combined type^ICD-99-CM' }
+      specify { expect(ft1.performed_by_code).to eq '9999999^DUCK^DONALD^D' }
+      specify { expect(ft1.ordered_by_code).to eq '9999999^DUCK^DONALD^D' }
       specify { expect(ft1.unit_cost).to eq '' }
-      specify { expect(ft1.filler_order_number).to eq '' }
+      specify { expect(ft1.filler_order_number).to eq '^99999999' }
       specify { expect(ft1.entered_by_code).to eq '' }
-      specify { expect(ft1.procedure_code).to eq '' }
+      specify { expect(ft1.procedure_code).to eq '99999^EACH ADDITIONAL 30 MINUTES FOR CRISIS PSYCHOTHERAPY' }
       specify { expect(ft1.procedure_code_modifier).to eq nil }
       specify { expect(ft1.advanced_beneficiary_notice_code).to eq nil }
       specify { expect(ft1.medically_necessary_duplicate_procedure_reason).to eq nil }

--- a/spec/ft1_segment_spec.rb
+++ b/spec/ft1_segment_spec.rb
@@ -1,0 +1,44 @@
+# encoding: UTF-8
+require 'spec_helper'
+
+describe HL7::Message::Segment::FT1 do
+  describe 'initialization' do
+    context 'with payload' do
+      # from https://docs.google.com/document/d/1yu4NSdkDSiGXZhhtA_ox__LinD_mdScq58ACw5bf2-g/edit
+      let(:payload) { 'FT1||||20091007000000|20091014|CG||||1|||||||||780.4^Dizziness/Giddiness~785.2^Heart Murmur~272.0^Hypercholesterolemia Pure~458.9^Hypotension Nos||||||99261^Consult' }
+
+      let(:ft1) { described_class.new payload }
+
+      specify { expect { ft1 }.to_not raise_error }
+
+      specify { expect(ft1.set_id).to eq '' }
+      specify { expect(ft1.transaction_id).to eq '' }
+      specify { expect(ft1.transaction_batch_id).to eq '' }
+      specify { expect(ft1.transaction_date).to eq '20091007000000' }
+      specify { expect(ft1.transaction_posting_date).to eq '20091014' }
+      specify { expect(ft1.transaction_type).to eq 'CG' }
+      specify { expect(ft1.transaction_code).to eq '' }
+      specify { expect(ft1.transaction_description).to eq '' }
+      specify { expect(ft1.transaction_description_alt).to eq '' }
+      specify { expect(ft1.transaction_quantity).to eq '1' }
+      specify { expect(ft1.transaction_amount_extended).to eq '' }
+      specify { expect(ft1.transaction_amount_unit).to eq '' }
+      specify { expect(ft1.department_code).to eq '' }
+      specify { expect(ft1.insurance_plan_id).to eq '' }
+      specify { expect(ft1.insurance_amount).to eq '' }
+      specify { expect(ft1.assigned_patient_location).to eq '' }
+      specify { expect(ft1.fee_schedule).to eq '' }
+      specify { expect(ft1.patient_type).to eq '' }
+      specify { expect(ft1.diagnosis_code).to eq '780.4^Dizziness/Giddiness~785.2^Heart Murmur~272.0^Hypercholesterolemia Pure~458.9^Hypotension Nos' }
+      specify { expect(ft1.performed_by_code).to eq '' }
+      specify { expect(ft1.ordered_by_code).to eq '' }
+      specify { expect(ft1.unit_cost).to eq '' }
+      specify { expect(ft1.filler_order_number).to eq '' }
+      specify { expect(ft1.entered_by_code).to eq '' }
+      specify { expect(ft1.procedure_code).to eq '99261^Consult' }
+      specify { expect(ft1.procedure_code_modifier).to eq nil }
+      specify { expect(ft1.advanced_beneficiary_notice_code).to eq nil }
+      specify { expect(ft1.medically_necessary_duplicate_procedure_reason).to eq nil }
+    end
+  end
+end

--- a/spec/ft1_segment_spec.rb
+++ b/spec/ft1_segment_spec.rb
@@ -4,38 +4,38 @@ require 'spec_helper'
 describe HL7::Message::Segment::FT1 do
   describe 'initialization' do
     context 'with payload' do
-      # from https://docs.google.com/document/d/1yu4NSdkDSiGXZhhtA_ox__LinD_mdScq58ACw5bf2-g/edit
-      let(:payload) { 'FT1||||20091007000000|20091014|CG||||1|||||||||780.4^Dizziness/Giddiness~785.2^Heart Murmur~272.0^Hypercholesterolemia Pure~458.9^Hypotension Nos||||||99261^Consult' }
+      # from http://www.hosinc.com/Products/Interfaces/interface_documentation.htm
+      let(:payload) { 'FT1|1|48390||20050111|20050112|CH|66000230^AMLODIPINE BESYLATE|AMLODIPINE BESYLATE||1|||1|||||I|||||||' }
 
       let(:ft1) { described_class.new payload }
 
       specify { expect { ft1 }.to_not raise_error }
 
-      specify { expect(ft1.set_id).to eq '' }
-      specify { expect(ft1.transaction_id).to eq '' }
+      specify { expect(ft1.set_id).to eq '1' }
+      specify { expect(ft1.transaction_id).to eq '48390' }
       specify { expect(ft1.transaction_batch_id).to eq '' }
-      specify { expect(ft1.transaction_date).to eq '20091007000000' }
-      specify { expect(ft1.transaction_posting_date).to eq '20091014' }
-      specify { expect(ft1.transaction_type).to eq 'CG' }
-      specify { expect(ft1.transaction_code).to eq '' }
-      specify { expect(ft1.transaction_description).to eq '' }
+      specify { expect(ft1.transaction_date).to eq '20050111' }
+      specify { expect(ft1.transaction_posting_date).to eq '20050112' }
+      specify { expect(ft1.transaction_type).to eq 'CH' }
+      specify { expect(ft1.transaction_code).to eq '66000230^AMLODIPINE BESYLATE' }
+      specify { expect(ft1.transaction_description).to eq 'AMLODIPINE BESYLATE' }
       specify { expect(ft1.transaction_description_alt).to eq '' }
       specify { expect(ft1.transaction_quantity).to eq '1' }
       specify { expect(ft1.transaction_amount_extended).to eq '' }
       specify { expect(ft1.transaction_amount_unit).to eq '' }
-      specify { expect(ft1.department_code).to eq '' }
+      specify { expect(ft1.department_code).to eq '1' }
       specify { expect(ft1.insurance_plan_id).to eq '' }
       specify { expect(ft1.insurance_amount).to eq '' }
       specify { expect(ft1.assigned_patient_location).to eq '' }
       specify { expect(ft1.fee_schedule).to eq '' }
-      specify { expect(ft1.patient_type).to eq '' }
-      specify { expect(ft1.diagnosis_code).to eq '780.4^Dizziness/Giddiness~785.2^Heart Murmur~272.0^Hypercholesterolemia Pure~458.9^Hypotension Nos' }
+      specify { expect(ft1.patient_type).to eq 'I' }
+      specify { expect(ft1.diagnosis_code).to eq '' }
       specify { expect(ft1.performed_by_code).to eq '' }
       specify { expect(ft1.ordered_by_code).to eq '' }
       specify { expect(ft1.unit_cost).to eq '' }
       specify { expect(ft1.filler_order_number).to eq '' }
       specify { expect(ft1.entered_by_code).to eq '' }
-      specify { expect(ft1.procedure_code).to eq '99261^Consult' }
+      specify { expect(ft1.procedure_code).to eq '' }
       specify { expect(ft1.procedure_code_modifier).to eq nil }
       specify { expect(ft1.advanced_beneficiary_notice_code).to eq nil }
       specify { expect(ft1.medically_necessary_duplicate_procedure_reason).to eq nil }

--- a/spec/gt1_segment_spec.rb
+++ b/spec/gt1_segment_spec.rb
@@ -1,0 +1,19 @@
+# encoding: UTF-8
+require 'spec_helper'
+
+describe HL7::Message::Segment::GT1 do
+  describe 'initialization' do
+    context 'with payload' do
+      # based on FT1 payload from http://www.hosinc.com/Products/Interfaces/interface_documentation.htm
+      let(:payload) { 'GT1|1|2857217|TEST^FIRST||158 N WASHINGTON ST^^MADISON^WI^54563^USA^^^GREEN LAKE|(920)867-5309||19800934|F|P/F|18\S\PARENT||||||^^^^^USA|||NONE' }
+
+      let(:gt1) { described_class.new payload }
+
+      specify { expect { gt1 }.to_not raise_error }
+
+      specify { expect(gt1.set_id).to eq '1' }
+      specify { expect(gt1.guarantor_number).to eq '2857217' }
+      specify { expect(gt1.guarantor_name).to eq 'TEST^FIRST' }
+    end
+  end
+end

--- a/spec/gt1_segment_spec.rb
+++ b/spec/gt1_segment_spec.rb
@@ -10,9 +10,6 @@ describe HL7::Message::Segment::GT1 do
       let(:gt1) { described_class.new payload }
 
       specify { expect { gt1 }.to_not raise_error }
-
-      specify { expect(gt1.set_id).to eq '1' }
-      specify { expect(gt1.guarantor_number).to eq '2857217' }
       specify { expect(gt1.guarantor_name).to eq 'TEST^FIRST' }
     end
   end


### PR DESCRIPTION
Add support for the `FT1` segment in DFT (Financial Files) 

A couple of questions / notes we might want to address before merging:

 * I'm not sure if we need to add `has_children` to `MSH` to ensure the `FT1` is parsed. Would you try this branch integrated in your context and we can modify further if necessary?

 * Do you know if `FT1` needs a `weight`? If so, I'm thinking it should get `weight 4`, i.e., `PV2 + 1`, since it always seems to come after `PV2`. Thoughts?

 * `procedure_code_modifier`, `advanced_beneficiary_notice_code`, and `medically_necessary_duplicate_procedure_reason` seem to be extraneous fields. i.e., each `FT1` block has 25 fields, but these 3 make a total of 28, so they end up as `nil` (not `''`). Where did these fields come from? I don't see them in the `HL7` specifications.

Thanks!

